### PR TITLE
Add option for allowing command loot to be executed for offline players

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pers.xanadu</groupId>
     <artifactId>EnderDragon</artifactId>
-    <version>2.5.6</version>
+    <version>2.5.7</version>
     <packaging>jar</packaging>
 
     <name>EnderDragon</name>
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.2</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
 <!--            <systemPath>${basedir}/lib/PlaceholderAPI-2.11.2.jar</systemPath>-->
         </dependency>

--- a/src/main/java/pers/xanadu/enderdragon/listener/DragonDeathListener.java
+++ b/src/main/java/pers/xanadu/enderdragon/listener/DragonDeathListener.java
@@ -99,16 +99,12 @@ public class DragonDeathListener implements Listener {
     private static void handleSpecialLoot(final MyDragon myDragon, final EnderDragon dragon){
         List<Pair<String,Double>> list = DamageManager.getDamageList(dragon.getUniqueId());
         list.sort(DamageManager::sortByDamage);
-        Set<String> online_players = new HashSet<>();
-        Bukkit.getOnlinePlayers().forEach(player -> online_players.add(player.getName()));
         List<SpecialLoot> participants = myDragon.lootMap.get(0);
         boolean tag = participants != null;
         int size = list.size();
         for(int i=0;i<size;i++){
             Pair<String,Double> pair = list.get(i);
             String name = pair.first;
-            //玩家不在线
-            if(!online_players.contains(name)) continue;
             String damage = String.format("%.2f",pair.second);
             //所有参与者
             if(tag) participants.forEach(loot -> loot.accept(name,damage));

--- a/src/main/java/pers/xanadu/enderdragon/manager/DragonManager.java
+++ b/src/main/java/pers/xanadu/enderdragon/manager/DragonManager.java
@@ -281,7 +281,8 @@ public class DragonManager {
                 SpecialLoot specialLoot;
                 if("command".equals(type)){
                     List<String> commands = loot.getStringList("data");
-                    specialLoot = (player, damage) -> handleCommandLoot(commands,player,damage);
+                    boolean executeOffline = loot.getBoolean("execute-if-offline");
+                    specialLoot = (player, damage) -> handleCommandLoot(commands,player,damage,executeOffline);
                 }
                 else if("exp".equals(type)){
                     int amount = loot.getInt("data"+f.options().pathSeparator()+"amount");
@@ -325,8 +326,13 @@ public class DragonManager {
         dragon_names.add(myDragon.unique_name);
         sum += edge;
     }
-    private static void handleCommandLoot(List<String> list, String name, String damage){
+    private static void handleCommandLoot(List<String> list, String name, String damage, boolean executeOffline){
         if(list == null) return;
+
+        Player player = Bukkit.getPlayer(name);
+        if (player == null && !executeOffline)
+            return;
+
         for (String cmd : list) {
             if(cmd.equals("")) continue;
             plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(),cmd.replaceAll("%player%",name).replaceAll("%damage%",damage));


### PR DESCRIPTION
Adds a fix for https://github.com/iXanadu13/EnderDragon/issues/40 by removing the check for online players when dropping special loot (has no effect on exp loot).
Adds the option `execute-if-offline` to special loot config for compatibility and so server owners can decide if they want the command to run if the target is offline.